### PR TITLE
add WebpackDevServerPlugin

### DIFF
--- a/packages/webpack-dev-server-plugin/package.json
+++ b/packages/webpack-dev-server-plugin/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@hs/webpack-dev-server-plugin",
+  "version": "9.0.0-beta.2",
+  "license": "MIT",
+  "homepage": "https://github.com/HubSpot/asset-bender/tree/master/packages/webpack-dev-server-plugin",
+  "repository": "github:HubSpot/asset-bender",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/WebpackDevServerPlugin",
+  "scripts": {
+    "build": "babel src -d lib --root-mode upward",
+    "prepare": "yarn build --delete-dir-on-start"
+  }
+}

--- a/packages/webpack-dev-server-plugin/src/WebpackDevServerPlugin.js
+++ b/packages/webpack-dev-server-plugin/src/WebpackDevServerPlugin.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+export default class WebpackDevServerPlugin {
+  before: (app: any, server: any) => void;
+
+  apply(compiler: any) {
+    if (!compiler.options.devServer) {
+      throw new Error(
+        'To use webpack-dev-server plugins, you must include a `devServer` option in your webpack config'
+      );
+    }
+
+    const originalBefore = compiler.options.devServer.before;
+
+    compiler.options.devServer.before = (app, server) => {
+      if (originalBefore) {
+        originalBefore(app, server);
+      }
+
+      this.before(app, server);
+    };
+  }
+}

--- a/packages/webpack-dev-server-plugin/src/WebpackDevServerPlugin.js
+++ b/packages/webpack-dev-server-plugin/src/WebpackDevServerPlugin.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 export default class WebpackDevServerPlugin {
-  before: (app: any, server: any) => void;
+  before: (app: any, server: any, compiler: any) => void;
 
   apply(compiler: any) {
     if (!compiler.options.devServer) {
@@ -17,7 +17,7 @@ export default class WebpackDevServerPlugin {
         originalBefore(app, server);
       }
 
-      this.before(app, server);
+      this.before(app, server, compiler);
     };
   }
 }


### PR DESCRIPTION
webpack-dev-server doesn't support a plugin interface, only hooks for `before`, `after`, etc.

It's convenient to be able to easily combine multiple `before` hooks. The `WebpackDevServerPlugin` enables this using a traditional webpack plugin. It only supports `before`, because that's the only one we've used.

For example:

```js
class SomeExtraRoute extends WebpackDevServerPlugin {
  before() {
    app.get('/some/path', function(req, res) {
      res.json({ custom: 'response' });
    });
  }
}