### PR TITLE
fix CompilerStatePlugin to always resolve with compilation

### DIFF
--- a/packages/webpack-graphql/src/CompilerStatePlugin.js
+++ b/packages/webpack-graphql/src/CompilerStatePlugin.js
@@ -12,17 +12,9 @@ export default class CompilerStatePlugin {
   apply(compiler) {
     this.valid = false;
 
-    compiler.plugin('compilation', compilation => {
-      this.compilation = compilation;
-    });
-
-    compiler.plugin('done', () => {
+    compiler.plugin('done', ({ compilation }) => {
       this.valid = true;
-      process.nextTick(() => {
-        if (this.valid) {
-          this._resolve(this.compilation);
-        }
-      });
+      this._resolve(compilation);
     });
 
     // on compiling
@@ -39,14 +31,6 @@ export default class CompilerStatePlugin {
     compiler.plugin('invalid', invalidPlugin);
     compiler.plugin('watch-run', invalidAsyncPlugin);
     compiler.plugin('run', invalidAsyncPlugin);
-  }
-
-  onValid(listener) {
-    if (this.valid) {
-      listener(this.compilation);
-    } else {
-      this.promise.then(listener);
-    }
   }
 
   then(...args) {


### PR DESCRIPTION
Because the plugin is only added when the server has started, it could be after `compiler.plugin('compilation', ...)` has already happened.

This plugin was a bit more complicated than it needs to be-you could access `.compilation` at any point after the compilation started, but we don't need that for the GraphQL API. We can just get it from the `'done'  hook.