### PR TITLE
Expose Module/Chunk relationship in graphql schema

### DIFF
--- a/packages/webpack-graphql/src/data.js
+++ b/packages/webpack-graphql/src/data.js
@@ -133,6 +133,16 @@ const coreResolvers = {
     warnings(module) {
       return module.warnings.map(unwrapError);
     },
+
+    chunks(module) {
+      return module.getChunks();
+    }
+  },
+
+  Chunk: {
+    modules(chunk) {
+      return chunk.getModules();
+    }
   },
 
   Raw: {

--- a/packages/webpack-graphql/src/data.js
+++ b/packages/webpack-graphql/src/data.js
@@ -136,13 +136,13 @@ const coreResolvers = {
 
     chunks(module) {
       return module.getChunks();
-    }
+    },
   },
 
   Chunk: {
     modules(chunk) {
       return chunk.getModules();
-    }
+    },
   },
 
   Raw: {

--- a/packages/webpack-graphql/src/schema.graphql
+++ b/packages/webpack-graphql/src/schema.graphql
@@ -31,6 +31,7 @@ type Module {
   errorCount: Int!
   warnings: [Error!]!
   warningCount: Int!
+  chunks: [Chunk!]!
 }
 
 type SourceLocationRange {
@@ -75,6 +76,7 @@ type Chunk {
   name: String
   entrypoints: [Module!]!
   origins: [ChunkOrigin!]!
+  modules: [Module!]!
 }
 
 type Entrypoint {


### PR DESCRIPTION
This data is useful for bundle analysis and discoverability. 

Changes: 
- Add `chunks` field on `Module` type.
- Add `modules` field on `Chunk` type