### PR TITLE
Make the EnhancedModulePlugin compatible with webpack 4 (and 3)

### DIFF
--- a/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
+++ b/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
@@ -1,6 +1,8 @@
 import LoaderDependency from 'webpack/lib/dependencies/LoaderDependency';
 import ContextDependency from 'webpack/lib/dependencies/ContextDependency';
 
+import { addModuleDependencies } from './webpack-compat/compilation';
+
 class EnhancedLoaderContextDependency extends ContextDependency {}
 EnhancedLoaderContextDependency.prototype.type = 'enhanced-loader-context';
 
@@ -50,9 +52,10 @@ module.exports = class EnhancedLoaderPlugin {
 
             function doLoad(loaderContext, dep, module) {
               return new Promise((resolve, reject) => {
-                compilation.addModuleDependencies(
+                addModuleDependencies(
+                  compilation,
                   module,
-                  [[dep]],
+                  [dep],
                   true,
                   'blm',
                   false,

--- a/packages/webpack-enhanced-loader-plugin/src/webpack-compat/compilation.js
+++ b/packages/webpack-enhanced-loader-plugin/src/webpack-compat/compilation.js
@@ -1,0 +1,29 @@
+function isWebpack4(compilation) {
+  return !!compilation.compiler.resolverFactory;
+}
+
+function addModuleDependencies(
+  compilation,
+  module,
+  deps,
+  bail,
+  cacheGroup,
+  recursive,
+  callback
+) {
+  compilation.addModuleDependencies(
+    module,
+    isWebpack4(compilation)
+      ? deps.map(dep => ({
+          factory: compilation.dependencyFactories.get(dep.constructor),
+          dependencies: [dep],
+        }))
+      : [deps],
+    bail,
+    cacheGroup,
+    recursive,
+    callback
+  );
+}
+
+module.exports = { addModuleDependencies };


### PR DESCRIPTION
["Documentation"](https://github.com/webpack/webpack/blob/master/lib/dependencies/LoaderPlugin.js#L59)

`compilation.compiler.resolverFactory` is the hint I'm using to determine if we're running webpack 4. I think anything else would be just as hacky.