### PR TITLE
webpack4: Make sporks-loader compatible with webpack 4 (and 3)

### DIFF
--- a/packages/sporks-loader/package.json
+++ b/packages/sporks-loader/package.json
@@ -10,6 +10,7 @@
   "main": "lib",
   "dependencies": {
     "@hs/sporks": "9.0.1",
+    "loader-utils": "^1.2.3",
     "webpack-sources": "^1.3.0"
   },
   "peerDependencies": {

--- a/packages/sporks-loader/src/index.js
+++ b/packages/sporks-loader/src/index.js
@@ -3,6 +3,7 @@
 import type { ParseResult } from '@hs/sporks';
 import path from 'path';
 import Sources from 'webpack-sources';
+import { getOptions } from 'loader-utils';
 
 type WebpackModule = {
   meta: ParseResult & { sporksStacks?: Array<any> },
@@ -43,7 +44,9 @@ module.exports = function(source: string, sourceMap: any) {
   this.cacheable();
 
   // FIXME document this option
-  const { types = {}, replaceExtensions = {} } = this.options.resolve;
+  const options = getOptions(this) || {};
+  const resolveOptions = options.resolve || {};
+  const { types = {}, replaceExtensions = {} } = resolveOptions;
 
   const rootModule: WebpackModule = this._module;
 
@@ -142,7 +145,7 @@ module.exports = function(source: string, sourceMap: any) {
             if (ext !== '.js') {
               throw new Error('require_env is only allowed in .js files');
             }
-            const env = this.options.sporksEnv || 'development';
+            const env = options.sporksEnv || 'development';
             return handlers.require(`./${name}.${env}.js`);
           },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,10 @@ big-integer@^1.6.17:
   version "1.6.36"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.36.tgz#78631076265d4ae3555c04f85e7d9d2f3a071a36"
 
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+
 binary-extensions@^1.0.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.12.0.tgz#c2d780f53d45bba8317a8902d4ceeaf3a6385b14"
@@ -1975,6 +1979,10 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -3729,6 +3737,12 @@ json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -3852,6 +3866,14 @@ load-json-file@^4.0.0:
     parse-json "^4.0.0"
     pify "^3.0.0"
     strip-bom "^3.0.0"
+
+loader-utils@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^2.0.0"
+    json5 "^1.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
`this.options` was removed in webpack 4
https://webpack.js.org/api/loaders/#this-options

Also, the options (`sporksEnv`, `resolve`) need to be provided to the rule directly. Previously, these were just tacked onto the `compiler` options and accessed in the loader.