### PR TITLE
Webpack4 enhanced loader context dependency

### DIFF
--- a/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
+++ b/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
@@ -44,7 +44,6 @@ module.exports = class EnhancedLoaderPlugin {
               module = loaderModule
             ) {
               const dep = EnhancedLoaderContextDependency.create(
-                compilation,
                 request,
                 recursive,
                 regExp,

--- a/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
+++ b/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
@@ -2,9 +2,11 @@ import LoaderDependency from 'webpack/lib/dependencies/LoaderDependency';
 import ContextDependency from 'webpack/lib/dependencies/ContextDependency';
 
 import { addModuleDependencies } from './webpack-compat/compilation';
+import { create } from './webpack-compat/context-dependency';
 
 class EnhancedLoaderContextDependency extends ContextDependency {}
 EnhancedLoaderContextDependency.prototype.type = 'enhanced-loader-context';
+EnhancedLoaderContextDependency.create = create;
 
 /**
  * Like the webpack LoaderPlugin, with promises and context support.
@@ -41,10 +43,12 @@ module.exports = class EnhancedLoaderPlugin {
               regExp,
               module = loaderModule
             ) {
-              const dep = new EnhancedLoaderContextDependency(
+              const dep = EnhancedLoaderContextDependency.create(
+                compilation,
                 request,
                 recursive,
-                regExp
+                regExp,
+                'sync'
               );
               dep.loc = request;
               return doLoad(this, dep, module);

--- a/packages/webpack-enhanced-loader-plugin/src/webpack-compat/context-dependency.js
+++ b/packages/webpack-enhanced-loader-plugin/src/webpack-compat/context-dependency.js
@@ -1,0 +1,18 @@
+import ContextDependency from 'webpack/lib/dependencies/ContextDependency';
+
+function isWebpack4(compilation) {
+  return !!compilation.compiler.resolverFactory;
+}
+
+function create(compilation, request, recursive, regExp, mode) {
+  if (!(this.prototype !== ContextDependency.prototype)) {
+    throw new Error('Cannot call `create` on non-ContextDependency');
+  }
+  if (isWebpack4(compilation)) {
+    return new this({ request, recursive, regExp, mode });
+  } else {
+    return new this(request, recursive, regExp);
+  }
+}
+
+module.exports = { create };

--- a/packages/webpack-enhanced-loader-plugin/src/webpack-compat/context-dependency.js
+++ b/packages/webpack-enhanced-loader-plugin/src/webpack-compat/context-dependency.js
@@ -1,7 +1,7 @@
 import ContextDependency from 'webpack/lib/dependencies/ContextDependency';
 
 function isWebpack4() {
-  // this instancce method exists in webpack 3 but not 4
+  // this instance method exists in webpack 3 but not 4
   return ContextDependency.prototype.isEqualResource == null;
 }
 

--- a/packages/webpack-enhanced-loader-plugin/src/webpack-compat/context-dependency.js
+++ b/packages/webpack-enhanced-loader-plugin/src/webpack-compat/context-dependency.js
@@ -1,14 +1,15 @@
 import ContextDependency from 'webpack/lib/dependencies/ContextDependency';
 
-function isWebpack4(compilation) {
-  return !!compilation.compiler.resolverFactory;
+function isWebpack4() {
+  // this instancce method exists in webpack 3 but not 4
+  return ContextDependency.prototype.isEqualResource == null;
 }
 
-function create(compilation, request, recursive, regExp, mode) {
+function create(request, recursive, regExp, mode) {
   if (!(this.prototype !== ContextDependency.prototype)) {
     throw new Error('Cannot call `create` on non-ContextDependency');
   }
-  if (isWebpack4(compilation)) {
+  if (isWebpack4()) {
     return new this({ request, recursive, regExp, mode });
   } else {
     return new this(request, recursive, regExp);


### PR DESCRIPTION
The `ContextDependency` constructor is different between webpack 3 and 4. This PR adds a `create` helper that detects the version and invoke the constructor accordingly.