### PR TITLE
Prevent resource query preservation while handling require_lang

### DIFF
--- a/packages/sporks-loader/src/index.js
+++ b/packages/sporks-loader/src/index.js
@@ -163,7 +163,10 @@ module.exports = function(source: string, sourceMap: any) {
                 `Cannot use require_lang without including the language wildcard ('*')`
               );
             }
-            const currentLang = path.basename(mod.resource, '.lyaml');
+            const currentLang = path.basename(
+              parseResourcePath(mod.resource),
+              '.lyaml'
+            );
             return handlers.require(p.replace('*', currentLang));
           },
         };


### PR DESCRIPTION
Fix unhandled resource queries to prevent:

```
> p
"./subdir/*.lyaml"
> currentLang
"en.lyaml?sporks&module-asset"
> p.replace('*', currentLang)
"./subdir/en.lyaml?sporks&module-asset.lyaml"
```

The expected result of the `replace` call should be `./subdir/en.lyaml`.