### PR TITLE
Handle Buffer asset sources

### DIFF
--- a/packages/webpack-graphql/src/data.js
+++ b/packages/webpack-graphql/src/data.js
@@ -167,6 +167,13 @@ const coreResolvers = {
       return dep.loc && dep.loc.start ? dep.loc : null;
     },
   },
+
+  Source: {
+    source(s) {
+      const value = s.source();
+      return Buffer.isBuffer(value) ? null : value;
+    },
+  },
 };
 
 export function buildContext(compiler) {

--- a/packages/webpack-graphql/src/schema.graphql
+++ b/packages/webpack-graphql/src/schema.graphql
@@ -53,7 +53,7 @@ type Dependency {
 
 # Source, including sourcemap
 type Source {
-  source: String!
+  source: String
   size(limit: Int): Int!
   map: Raw
 }


### PR DESCRIPTION
webpack-graphql would crash if an asset's source was a Buffer.