### PR TITLE
sporks: Include directive line # in loc

### DIFF
--- a/packages/sporks/__tests__/index.js
+++ b/packages/sporks/__tests__/index.js
@@ -13,6 +13,7 @@ Object {
       ],
       "directive": "hello",
       "loc": Object {
+        "line": 1,
         "start": 0,
       },
       "source": "#= hello world",
@@ -34,6 +35,7 @@ Object {
       ],
       "directive": "hello",
       "loc": Object {
+        "line": 1,
         "start": 0,
       },
       "source": "//= hello world",
@@ -41,6 +43,63 @@ Object {
   ],
   "headerSource": "//= hello world",
   "source": "",
+}
+`);
+  });
+
+  it('parses multiple lines', () => {
+    expect(parse('#= hello world\n#= hello mars\n#\n\n#= hello venus\n\n'))
+      .toMatchInlineSnapshot(`
+Object {
+  "directives": Array [
+    Object {
+      "args": Array [
+        "world",
+      ],
+      "directive": "hello",
+      "loc": Object {
+        "line": 1,
+        "start": 0,
+      },
+      "source": "#= hello world",
+    },
+    Object {
+      "args": Array [
+        "mars",
+      ],
+      "directive": "hello",
+      "loc": Object {
+        "line": 2,
+        "start": 0,
+      },
+      "source": "#= hello mars",
+    },
+    Object {
+      "args": Array [
+        "venus",
+      ],
+      "directive": "hello",
+      "loc": Object {
+        "line": 5,
+        "start": 0,
+      },
+      "source": "#= hello venus",
+    },
+  ],
+  "headerSource": "#= hello world
+#= hello mars
+#
+
+#= hello venus
+
+",
+  "source": "
+
+#
+
+
+
+",
 }
 `);
   });

--- a/packages/sporks/src/index.js
+++ b/packages/sporks/src/index.js
@@ -5,7 +5,7 @@ import shellwords from 'shellwords';
 export type Directive = {
   directive: string,
   args: Array<string>,
-  loc: { start: number },
+  loc: { line: number, start: number },
   source: string,
 };
 
@@ -36,7 +36,7 @@ export function parse(source: string): ParseResult {
   const bodySource = source.substr(headerSource.length);
 
   const directives = [];
-  const headerLines = headerSource.split('\n').map(line => {
+  const headerLines = headerSource.split('\n').map((line, index) => {
     const match = line.match(/^(\W*=)\s*(\w+)\s*(.*?)(\*\/)?$/);
     if (!match) {
       return line;
@@ -47,6 +47,7 @@ export function parse(source: string): ParseResult {
       directive,
       args,
       loc: {
+        line: index + 1,
         // $FlowIssue https://github.com/facebook/flow/issues/3554
         start: match.index,
       },


### PR DESCRIPTION
Connects to internal issue: https://git.hubteam.com/HubSpot/faast-infra/issues/1813

Adds the directive line numbers to the sporks output to enable us to automatically inject new directives at the best location.

The line number is 1 indexed.