### PR TITLE
support string module ids

### DIFF
--- a/packages/webpack-graphql/src/schema.graphql
+++ b/packages/webpack-graphql/src/schema.graphql
@@ -19,7 +19,7 @@ type Module {
   buildTimestamp: Raw
   resource: String
   context: String
-  id: Int
+  id: String
   dependencies: [Dependency!]!
   reasons: [ModuleReason!]!
   issuer: Module


### PR DESCRIPTION
We had this change in a branch of our internal mirror but it recently got lost.