### PR TITLE
use getter instead of modifying prototype

### DIFF
--- a/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
+++ b/packages/webpack-enhanced-loader-plugin/src/EnhancedLoaderPlugin.js
@@ -5,8 +5,11 @@ import { addModuleDependencies } from './webpack-compat/compilation';
 import { create } from './webpack-compat/context-dependency';
 import { buildInfo } from './webpack-compat/normal-module';
 
-class EnhancedLoaderContextDependency extends ContextDependency {}
-EnhancedLoaderContextDependency.prototype.type = 'enhanced-loader-context';
+class EnhancedLoaderContextDependency extends ContextDependency {
+  get type() {
+    return 'enhanced-loader-context';
+  }
+}
 EnhancedLoaderContextDependency.create = create;
 
 /**


### PR DESCRIPTION
This no longer works in webpack 5 where `type` is a [getter in `Dependency`](https://github.com/webpack/webpack/blob/v5.48.0/lib/Dependency.js#L110-L112)

This lines up with how webpack itself overrides `type` in subclasses. https://github.com/webpack/webpack/blob/6d24d111f89e5d5bdeec2b021e89944ff5a391ac/lib/dependencies/PrefetchDependency.js#L15-L17