### PR TITLE
[webpack-graphql] Store full assets individually via assetEmitted tap

### DIFF
--- a/packages/webpack-graphql/src/data.js
+++ b/packages/webpack-graphql/src/data.js
@@ -222,11 +222,16 @@ export function buildContext(compiler) {
     callback();
   });
 
-  compiler.hooks.emit.tap('webpack-graphql', compilation => {
-    assetsByCompilation.set(compilation, {
-      ...compilation.assets,
-    });
-  });
+  compiler.hooks.assetEmitted.tap(
+    'webpack-graphql',
+    (file, { compilation, source }) => {
+      const assetsForCompilation = assetsByCompilation.get(compilation) || {};
+      assetsByCompilation.set(compilation, {
+        ...assetsForCompilation,
+        [file]: source,
+      });
+    }
+  );
 
   return context;
 }


### PR DESCRIPTION
It is possible for assets to be added to the compilation object (e.g. via `compilation.emitAsset`) after this plugin's tap of the `emit` hook is called. For example, a different plugin can tap the emit hook later on and call `compilation.emitAsset`.

By using the `assetEmitted` hook, we ensure that each new asset is added to our `WeakMap` as it is emitted which ensures that all assets wind up available when we create the `assets` value in our `Compilation.assets` resolver.