### PR TITLE
Replace deprecated usage of errors and warnings properties

### DIFF
--- a/packages/webpack-graphql/src/data.js
+++ b/packages/webpack-graphql/src/data.js
@@ -88,19 +88,19 @@ const coreResolvers = {
     },
 
     errorCount(compilation) {
-      return compilation.errors.length;
+      return compilation.getErrors().length;
     },
 
     errors(compilation) {
-      return compilation.errors.map(unwrapError);
+      return compilation.getErrors().map(unwrapError);
     },
 
     warningCount(compilation) {
-      return compilation.warnings.length;
+      return compilation.getWarnings().length;
     },
 
     warnings(compilation) {
-      return compilation.warnings.map(unwrapError);
+      return compilation.getWarnings().map(unwrapError);
     },
   },
 
@@ -128,19 +128,21 @@ const coreResolvers = {
     },
 
     errorCount(module) {
-      return module.errors.length;
+      return module.getNumberOfErrors();
     },
 
     errors(module) {
-      return module.errors.map(unwrapError);
+      const errors = module.getErrors();
+      return errors ? errors.map(unwrapError) : [];
     },
 
     warningCount(module) {
-      return module.warnings.length;
+      return module.getNumberOfWarnings();
     },
 
     warnings(module) {
-      return module.warnings.map(unwrapError);
+      const warnings = module.getWarnings();
+      return warnings ? warnings.map(unwrapError) : [];
     },
 
     chunks(module) {


### PR DESCRIPTION
This PR updates the GraphQL resolvers related to error and warnings fields to use non-deprecated methods. The `getErrors()` and `getWarnings()` methods of the `Compilation` will [use the `processErrors` and `processWarnings` hooks](https://github.com/webpack/webpack/blob/7168389ac65dcc6bfbffa524e003acf7911da71a/lib/Compilation.js#L4981-L4987) respectively to filter the results. We are planning to rely on the `ignoreWarnings` [configuration option](https://webpack.js.org/configuration/other-options/#ignorewarnings) and it [depends on the `processWarnings` hook](https://github.com/webpack/webpack/blob/7168389ac65dcc6bfbffa524e003acf7911da71a/lib/IgnoreWarningsPlugin.js#L26-L29) so without this fix the GraphQL response will not match what the user sees in the console.

The changes for the fields on the `Module` type are not strictly needed for our feature but were related enough that I chose to do it in the PR.
